### PR TITLE
Feat/37 livestream crud

### DIFF
--- a/web_backend/src/web_backend.Application.Contracts/Livestreams/CreateLivestreamDto.cs
+++ b/web_backend/src/web_backend.Application.Contracts/Livestreams/CreateLivestreamDto.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using web_backend.Enums;
+
+namespace web_backend.Livestreams
+{
+    public class CreateLivestreamDto
+    {
+        public string HlsUrl { get; set; }
+        public string HomeTeam { get; set; }
+        public string AwayTeam { get; set; }
+        public int HomeScore { get; set; } = 0;
+        public int AwayScore { get; set; } = 0;
+        public EventType EventType { get; set; }
+        public StreamStatus StreamStatus { get; set; }
+    }
+}

--- a/web_backend/src/web_backend.Application.Contracts/Livestreams/ILivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application.Contracts/Livestreams/ILivestreamAppService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace web_backend.Livestreams
+{
+    public interface ILivestreamAppService : IApplicationService
+    {
+    }
+}

--- a/web_backend/src/web_backend.Application.Contracts/Livestreams/LivestreamDto.cs
+++ b/web_backend/src/web_backend.Application.Contracts/Livestreams/LivestreamDto.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using web_backend.Enums;
+
+namespace web_backend.Livestreams
+{
+    public class LivestreamDto
+    {
+        public Guid Id { get; set; }
+        public string HlsUrl { get; set; }
+        public string HomeTeam { get; set; }
+        public string AwayTeam { get; set; }
+        public int HomeScore { get; set; } = 0;
+        public int AwayScore { get; set; } = 0;
+        public string GameScore
+        {
+            get
+            {
+                return $"{HomeScore} - {AwayScore}";
+            }
+        }
+        public EventType EventType { get; set; }
+        public StreamStatus StreamStatus { get; set; }
+    }
+}

--- a/web_backend/src/web_backend.Application.Contracts/Livestreams/LivestreamFilterDto.cs
+++ b/web_backend/src/web_backend.Application.Contracts/Livestreams/LivestreamFilterDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using web_backend.Enums;
+
+namespace web_backend.Livestreams
+{
+    public class LivestreamFilterDto
+    {
+        // All set to nullable in order to allow for proper filtering
+        public string? HomeTeam { get; set; }
+        public string? AwayTeam { get; set; }
+        public EventType? EventType { get; set; }
+        public StreamStatus? StreamStatus { get; set; }
+    }
+}

--- a/web_backend/src/web_backend.Application.Contracts/Livestreams/UpdateLivestreamDto.cs
+++ b/web_backend/src/web_backend.Application.Contracts/Livestreams/UpdateLivestreamDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using web_backend.Enums;
+
+namespace web_backend.Livestreams
+{
+    public class UpdateLivestreamDto
+    {
+        // All properties are nullable in order to allow partial updates
+        public string? HlsUrl { get; set; } 
+        public string? HomeTeam { get; set; } 
+        public string? AwayTeam { get; set; }  
+        public int? HomeScore { get; set; }  
+        public int? AwayScore { get; set; }  
+        public EventType? EventType { get; set; } 
+        public StreamStatus? StreamStatus { get; set; } 
+    }
+}

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
@@ -9,9 +9,33 @@ namespace web_backend.Livestreams
 {
     public class LivestreamAppService : ApplicationService, ILivestreamAppService
     {
-        public LivestreamAppService() 
-        { 
+        private readonly ILivestreamRepository _livestreamRepository;
+        public LivestreamAppService(
+            ILivestreamRepository livestreamRepository
+            )
+        {
+            _livestreamRepository = livestreamRepository;
+        }
 
+        // return specific instance of a livestream, if it exists
+        public async Task<LivestreamDto> GetAsync(Guid id)
+        {
+            // retrieve livestream information
+            var livestream = await _livestreamRepository.GetAsync(id);
+
+            // map livestream info onto Dto
+            var result = ObjectMapper.Map<Livestream, LivestreamDto>(livestream);
+
+            return result;
+
+        }
+
+        // return a list of every livestream table instance, regardless of status
+        public async Task<List<LivestreamDto>> GetListAsync()
+        {
+            var livestreams = await _livestreamRepository.GetListAsync();
+            var result = ObjectMapper.Map<List<Livestream>, List<LivestreamDto>>(livestreams);
+            return result;
         }
     }
 }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
@@ -6,6 +6,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 using Volo.Abp.Application.Services;
+using Volo.Abp.Domain.Entities;
 
 namespace web_backend.Livestreams
 {
@@ -54,6 +55,28 @@ namespace web_backend.Livestreams
 
             // map new entity onto livestreamDto and return
             var result = ObjectMapper.Map<Livestream, LivestreamDto>(createdLivestream);
+
+            return result;
+        }
+
+        // update livestream instance
+        public async Task<LivestreamDto> UpdateAsync(Guid id, UpdateLivestreamDto input)
+        {
+            // retrieve existing livestream
+            var livestream = await _livestreamRepository.GetAsync(id);
+            if(livestream == null)
+            {
+                throw new EntityNotFoundException(typeof(Livestream), id);
+            }
+
+            // map input dto onto existing livestream entity
+            ObjectMapper.Map(input, livestream);
+
+            // update livestream using _repository
+            var updatedLivestream = await _livestreamRepository.UpdateAsync(livestream);
+
+            // map updated entity onto livestreamDto and return
+            var result = ObjectMapper.Map<Livestream, LivestreamDto>(updatedLivestream);
 
             return result;
         }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using AutoMapper.Internal.Mappers;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 using Volo.Abp.Application.Services;
@@ -33,8 +35,26 @@ namespace web_backend.Livestreams
         // return a list of every livestream table instance, regardless of status
         public async Task<List<LivestreamDto>> GetListAsync()
         {
+            // retrieve a list of all livestreams
             var livestreams = await _livestreamRepository.GetListAsync();
+
+            // map livestream list onto dto and return
             var result = ObjectMapper.Map<List<Livestream>, List<LivestreamDto>>(livestreams);
+            return result;
+        }
+
+        // create livestream instance 
+        public async Task<LivestreamDto> CreateAsync(CreateLivestreamDto input)
+        {
+            // map input dto onto livestream 
+            var livestream = ObjectMapper.Map<CreateLivestreamDto, Livestream>(input);
+
+            // create livestream instance
+            var createdLivestream = await _livestreamRepository.CreateAsync(livestream);
+
+            // map new entity onto livestreamDto and return
+            var result = ObjectMapper.Map<Livestream, LivestreamDto>(createdLivestream);
+
             return result;
         }
     }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Application.Services;
+
+namespace web_backend.Livestreams
+{
+    public class LivestreamAppService : ApplicationService, ILivestreamAppService
+    {
+        public LivestreamAppService() 
+        { 
+
+        }
+    }
+}

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamAppService.cs
@@ -6,42 +6,52 @@ using System.Reflection.Metadata.Ecma335;
 using System.Text;
 using System.Threading.Tasks;
 using Volo.Abp.Application.Services;
+using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities;
+using Volo.Abp.MultiTenancy;
 
 namespace web_backend.Livestreams
 {
     public class LivestreamAppService : ApplicationService, ILivestreamAppService
     {
         private readonly ILivestreamRepository _livestreamRepository;
+        private readonly IDataFilter _dataFilter;
         public LivestreamAppService(
-            ILivestreamRepository livestreamRepository
+            ILivestreamRepository livestreamRepository,
+            IDataFilter dataFilter
             )
         {
             _livestreamRepository = livestreamRepository;
+            _dataFilter = dataFilter;
         }
 
         // return specific instance of a livestream, if it exists
         public async Task<LivestreamDto> GetAsync(Guid id)
         {
-            // retrieve livestream information
-            var livestream = await _livestreamRepository.GetAsync(id);
+            using (_dataFilter.Disable<IMultiTenant>())
+            {
+                // retrieve livestream information
+                var livestream = await _livestreamRepository.GetAsync(id);
 
-            // map livestream info onto Dto
-            var result = ObjectMapper.Map<Livestream, LivestreamDto>(livestream);
+                // map livestream info onto Dto
+                var result = ObjectMapper.Map<Livestream, LivestreamDto>(livestream);
 
-            return result;
-
+                return result;
+            }
         }
 
         // return a list of every livestream table instance, regardless of status
         public async Task<List<LivestreamDto>> GetListAsync()
         {
-            // retrieve a list of all livestreams
-            var livestreams = await _livestreamRepository.GetListAsync();
+            using (_dataFilter.Disable<IMultiTenant>())
+            {
+                // retrieve a list of all livestreams
+                var livestreams = await _livestreamRepository.GetListAsync();
 
-            // map livestream list onto dto and return
-            var result = ObjectMapper.Map<List<Livestream>, List<LivestreamDto>>(livestreams);
-            return result;
+                // map livestream list onto dto and return
+                var result = ObjectMapper.Map<List<Livestream>, List<LivestreamDto>>(livestreams);
+                return result;
+            }
         }
 
         // create livestream instance 
@@ -62,23 +72,62 @@ namespace web_backend.Livestreams
         // update livestream instance
         public async Task<LivestreamDto> UpdateAsync(Guid id, UpdateLivestreamDto input)
         {
-            // retrieve existing livestream
-            var livestream = await _livestreamRepository.GetAsync(id);
-            if(livestream == null)
+            using (_dataFilter.Disable<IMultiTenant>())
             {
-                throw new EntityNotFoundException(typeof(Livestream), id);
+                // retrieve existing livestream
+                var livestream = await _livestreamRepository.GetAsync(id);
+                if (livestream == null)
+                {
+                    throw new EntityNotFoundException(typeof(Livestream), id);
+                }
+
+                // map input dto onto existing livestream entity
+                ObjectMapper.Map(input, livestream);
+
+                // update livestream using _repository
+                var updatedLivestream = await _livestreamRepository.UpdateAsync(livestream);
+
+                // map updated entity onto livestreamDto and return
+                var result = ObjectMapper.Map<Livestream, LivestreamDto>(updatedLivestream);
+
+                return result;
+            }
+        }
+
+        // return a list of filtered livestreams
+        public async Task<List<LivestreamDto>> GetFilteredListAsync(LivestreamFilterDto input)
+        {
+            using (_dataFilter.Disable<IMultiTenant>())
+            {
+                // retrieve list of livestreams with the applied filters
+                var filteredLivestreams = await _livestreamRepository.GetFilteredListAsync(
+                input.EventType,
+                input.StreamStatus,
+                input.HomeTeam,
+                input.AwayTeam
+             );
+
+                // map the resulting list and return
+                var result = ObjectMapper.Map<List<Livestream>, List<LivestreamDto>>(filteredLivestreams);
+
+                return result;
             }
 
-            // map input dto onto existing livestream entity
-            ObjectMapper.Map(input, livestream);
+        }
+        public async Task DeleteAsync(Guid id)
+        {
+            using (_dataFilter.Disable<IMultiTenant>())
+            {
+                // verify existance
+                var livestream = await _livestreamRepository.GetAsync(id);
+                if (livestream == null)
+                {
+                    throw new EntityNotFoundException(typeof(Livestream), id);
+                }
 
-            // update livestream using _repository
-            var updatedLivestream = await _livestreamRepository.UpdateAsync(livestream);
-
-            // map updated entity onto livestreamDto and return
-            var result = ObjectMapper.Map<Livestream, LivestreamDto>(updatedLivestream);
-
-            return result;
+                // Delete the livestream using the repository
+                await _livestreamRepository.DeleteAsync(id);
+            }
         }
     }
 }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
@@ -13,6 +13,8 @@ namespace web_backend.Livestreams
         {
             CreateMap<Livestream, LivestreamDto>();
             CreateMap<CreateLivestreamDto, Livestream>();
+            CreateMap<UpdateLivestreamDto, Livestream>()
+            .ForAllMembers(opts => opts.Condition((src, dest, srcMember) => srcMember != null)); // Only map non-null values
         }
     }
 }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
@@ -12,6 +12,7 @@ namespace web_backend.Livestreams
         public LivestreamApplicationAutoMapperProfile()
         {
             CreateMap<Livestream, LivestreamDto>();
+            CreateMap<CreateLivestreamDto, Livestream>();
         }
     }
 }

--- a/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
+++ b/web_backend/src/web_backend.Application/Livestreams/LivestreamApplicationAutoMapperProfile.cs
@@ -1,0 +1,17 @@
+﻿using AutoMapper;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace web_backend.Livestreams
+{
+    public class LivestreamApplicationAutoMapperProfile : Profile
+    {
+        public LivestreamApplicationAutoMapperProfile()
+        {
+            CreateMap<Livestream, LivestreamDto>();
+        }
+    }
+}

--- a/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
+++ b/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
@@ -8,6 +8,9 @@ namespace web_backend.Livestreams
 {
     public interface ILivestreamRepository
     {
-        
+        Task<Livestream> GetAsync(Guid id);
+        Task<List<Livestream>> GetListAsync();
+        Task<Livestream> CreateAsync(Livestream livestream);
+
     }
 }

--- a/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
+++ b/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
@@ -11,6 +11,7 @@ namespace web_backend.Livestreams
         Task<Livestream> GetAsync(Guid id);
         Task<List<Livestream>> GetListAsync();
         Task<Livestream> CreateAsync(Livestream livestream);
+        Task<Livestream> UpdateAsync(Livestream livestream);
 
     }
 }

--- a/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
+++ b/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace web_backend.Livestreams
+{
+    public interface ILivestreamRepository
+    {
+        
+    }
+}

--- a/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
+++ b/web_backend/src/web_backend.Domain/Livestreams/ILivestreamRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using web_backend.Enums;
 
 namespace web_backend.Livestreams
 {
@@ -12,6 +13,7 @@ namespace web_backend.Livestreams
         Task<List<Livestream>> GetListAsync();
         Task<Livestream> CreateAsync(Livestream livestream);
         Task<Livestream> UpdateAsync(Livestream livestream);
-
+        Task<List<Livestream>> GetFilteredListAsync(EventType? eventType, StreamStatus? streamStatus, string? homeTeam, string? awayTeam);
+        Task DeleteAsync(Guid id);
     }
 }

--- a/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
+++ b/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
 using web_backend.EntityFrameworkCore;
+using web_backend.Enums;
 
 namespace web_backend.Livestreams
 {
@@ -42,6 +43,26 @@ namespace web_backend.Livestreams
             var updatedLivestream = await base.UpdateAsync(livestream);
 
             return updatedLivestream;
+        }
+
+        public async Task<List<Livestream>> GetFilteredListAsync(EventType? eventType, StreamStatus? streamStatus, string? homeTeam, string? awayTeam)
+        {
+            var query = await GetQueryableAsync();
+
+            // Create a list of filter functions based on individual filter parameters
+            query = new List<Func<IQueryable<Livestream>, IQueryable<Livestream>>>
+            {
+                q => eventType.HasValue ? q.Where(livestream => livestream.EventType == eventType) : q,
+                q => streamStatus.HasValue ? q.Where(livestream => livestream.StreamStatus == streamStatus) : q,
+                q => !string.IsNullOrWhiteSpace(homeTeam) ? q.Where(livestream => livestream.HomeTeam.Contains(homeTeam)) : q,
+                q => !string.IsNullOrWhiteSpace(awayTeam) ? q.Where(livestream => livestream.AwayTeam.Contains(awayTeam)) : q
+            }.Aggregate(query, (current, filter) => filter(current));
+
+            return await query.ToListAsync();
+        }
+        public async Task DeleteAsync(Guid id)
+        {
+            await base.DeleteAsync(id);
         }
     }
 }

--- a/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
+++ b/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
 using Volo.Abp.EntityFrameworkCore;
@@ -34,6 +35,13 @@ namespace web_backend.Livestreams
         public async Task<Livestream> CreateAsync(Livestream livestream)
         {
             return await InsertAsync(livestream);
+        }
+
+        public async Task<Livestream> UpdateAsync(Livestream livestream)
+        {
+            var updatedLivestream = await base.UpdateAsync(livestream);
+
+            return updatedLivestream;
         }
     }
 }

--- a/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
+++ b/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Volo.Abp.Domain.Repositories.EntityFrameworkCore;
+using Volo.Abp.EntityFrameworkCore;
+using web_backend.EntityFrameworkCore;
+
+namespace web_backend.Livestreams
+{
+    public class LivestreamRepository : EfCoreRepository<web_backendDbContext, Livestream, Guid>, ILivestreamRepository
+    {
+        public LivestreamRepository(IDbContextProvider<web_backendDbContext> dbContextProvider)
+            : base(dbContextProvider)
+        {
+        }
+    }
+}

--- a/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
+++ b/web_backend/src/web_backend.EntityFrameworkCore/Livestreams/LivestreamRepository.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.EntityFrameworkCore;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,25 @@ namespace web_backend.Livestreams
         public LivestreamRepository(IDbContextProvider<web_backendDbContext> dbContextProvider)
             : base(dbContextProvider)
         {
+        }
+
+        public async Task<Livestream> GetAsync(Guid id)
+        {
+            var query = await GetQueryableAsync();
+            var result = await query.FirstOrDefaultAsync(x => x.Id == id);
+
+            return result;
+        }
+
+        public async Task<List<Livestream>> GetListAsync()
+        {
+            var query = await GetQueryableAsync();
+            return await query.ToListAsync();
+        }
+
+        public async Task<Livestream> CreateAsync(Livestream livestream)
+        {
+            return await InsertAsync(livestream);
         }
     }
 }


### PR DESCRIPTION
Summary: Created CRUD APIs and a custom filtered list API, for livestreams along with all associated classes 

In depth:
- Create livestream API
- Get livestream API
- Get livestream list (unfiltered, all results) API
- Get livestream list (filtered by at least one or all of: home team, away team, event type, stream status) API
- Delete livestream API
- Multi-tenancy disabled on select APIs to ensure all results are properly sent back to the user 

See swagger for details on specific inputs 